### PR TITLE
Sync with upstream to get indexes for harvest tables 

### DIFF
--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -79,6 +79,14 @@ def setup():
         if "harvest_job_id_idx" not in index_names:
             log.debug('Creating index for harvest_object')
             Index("harvest_job_id_idx", harvest_object_table.c.harvest_job_id).create()
+        
+        if "harvest_source_id_idx" not in index_names:
+            log.debug('Creating index for harvest source')
+            Index("harvest_source_id_idx", harvest_object_table.c.harvest_source_id).create()
+        
+        if "package_id_idx" not in index_names:
+            log.debug('Creating index for package')
+            Index("package_id_idx", harvest_object_table.c.package_id).create()
 
 
 class HarvestError(Exception):
@@ -288,6 +296,8 @@ def define_harvester_tables():
         # report_status: 'added', 'updated', 'not modified', 'deleted', 'errored'
         Column('report_status', types.UnicodeText, nullable=True),
         Index('harvest_job_id_idx', 'harvest_job_id'),
+        Index('harvest_source_id_idx', 'harvest_source_id'),
+        Index('package_id_idx', 'package_id'),
     )
 
     # New table

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -88,6 +88,10 @@ def setup():
             log.debug('Creating index for package')
             Index("package_id_idx", harvest_object_table.c.package_id).create()
         
+        if "guid_idx" not in index_names:
+            log.debug('Creating index for guid')
+            Index("guid_idx", harvest_object_table.c.guid).create()
+        
         index_names = [index['name'] for index in inspector.get_indexes("harvest_object_extra")]
         if "harvest_object_id_idx" not in index_names:
             log.debug('Creating index for harvest_object_extra')
@@ -303,6 +307,7 @@ def define_harvester_tables():
         Index('harvest_job_id_idx', 'harvest_job_id'),
         Index('harvest_source_id_idx', 'harvest_source_id'),
         Index('package_id_idx', 'package_id'),
+        Index('guid_idx', 'guid'),
     )
 
     # New table

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -87,6 +87,11 @@ def setup():
         if "package_id_idx" not in index_names:
             log.debug('Creating index for package')
             Index("package_id_idx", harvest_object_table.c.package_id).create()
+        
+        index_names = [index['name'] for index in inspector.get_indexes("harvest_object_extra")]
+        if "harvest_object_id_idx" not in index_names:
+            log.debug('Creating index for harvest_object_extra')
+            Index("harvest_object_id_idx", harvest_object_extra_table.c.harvest_object_id).create()
 
 
 class HarvestError(Exception):
@@ -308,6 +313,7 @@ def define_harvester_tables():
         Column('harvest_object_id', types.UnicodeText, ForeignKey('harvest_object.id')),
         Column('key', types.UnicodeText),
         Column('value', types.UnicodeText),
+        Index('harvest_object_id_idx', 'harvest_object_id'),
     )
 
     # New table


### PR DESCRIPTION
Related to [Multi#403](https://github.com/GSA/datagov-ckan-multi/issues/403)

This PR sync commits from upstream
After upstream repo merged [our PR](https://github.com/ckan/ckanext-harvest/pull/414/commits) about harvest table indexes we need to get them to our fork

This PR includes
```
git cherry-pick 852a4d8
git cherry-pick c6d5383
git cherry-pick 316a1fd
```

All pending commits now:
```
git log datagov-catalog..upstream/master --oneline

d92864a (upstream/master) Merge pull request #414 from avdata99/av/upmaster

852a4d8 Add index for harvest_object.guid
c6d5383 Add an index for HarvetObjectExtra
316a1fd Add more indexes to Harvest objects

df34890 (tag: v1.3.1) Update to version 1.3.1
da0e134 Merge branch 'master' of github.com:ckan/ckanext-harvest
bbff4e2 Merge branch 'mutantsan-abort-failed-jobs-cli-command'
cb69ea5 (upstream/mutantsan-abort-failed-jobs-cli-command) Fix py3 ref
7ba9c6c Merge branch 'abort-failed-jobs-cli-command' of https://github.com/mutantsan/ckanext-harvest into mutantsan-abort-failed-jobs-cli-command
f0fb4f7 Merge pull request #413 from bzar/fix-harvest_object_list-ref
b8b0a3b Merge branch 'fix-redis-requirement'
8e79897 Skip master tests until fanstatic is dealt with
9c4b0b2 (upstream/fix-redis-requirement) Unpin redis requirement
6d78415 Unpin redis requirement
6c78efc Fix tests, improve Travis setup
5e97bb4 Fix harvest_object_list member reference
e494524 Fix travis build installing the right setuptools version
2ca4b67 Merge pull request #412 from vrk-kpa/fix_resending_objects_to_queue
af8c18e Fix resending objects to queue
2594673 Merge pull request #410 from vrk-kpa/fix_cli_commands
819672a Do not use request as it is not available in cli
19b737f fix tests problems
556136d write pytests
6c70200 write nose tests
02f9c60 implement abort_failed_jobs click command
54a6f59 implement abort_failed_jobs paster command
dfe7c84 implement harvest_abort_failed_jobs action
```