### PR TITLE
Remove dash to prevent ckan-to-ckan character validation

### DIFF
--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -287,7 +287,7 @@ class HarvesterBase(SingletonPlugin):
             try:
                 log.debug('Attempting adding unique Identifier to name %s' % package_dict['name'])
                 model.Session.rollback()
-                package_dict['name'] = '%s-%s' % (package_dict['name'], str(uuid.uuid4())[:5])
+                package_dict['name'] = '%s%s' % (package_dict['name'], str(uuid.uuid4())[:5])
                 new_package = get_action('package_create_rest')(context, package_dict)
                 harvest_object.current = True
                 harvest_object.package_id = package_dict['id']

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -287,7 +287,7 @@ class HarvesterBase(SingletonPlugin):
             try:
                 log.debug('Attempting adding unique Identifier to name %s' % package_dict['name'])
                 model.Session.rollback()
-                package_dict['name'] = '%s%s' % (package_dict['name'], str(uuid.uuid4())[:5])
+                package_dict['name'] = '%s-%s' % (package_dict['name'], str(uuid.uuid4())[:4])
                 new_package = get_action('package_create_rest')(context, package_dict)
                 harvest_object.current = True
                 harvest_object.package_id = package_dict['id']


### PR DESCRIPTION
This is only found in the ckan-to-ckan harvester. This extra "-" causes the name to be 101 characters and will fail the 100 character validation check.

This function is only used in ckan-to-ckan harvest sources.