### PR TITLE
fix for py3 also works for py2; 

### DIFF
--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -133,7 +133,7 @@ def harvest_source_extra_fields():
     for harvester in p.PluginImplementations(IHarvester):
         if not hasattr(harvester, 'extra_schema'):
             continue
-        fields[harvester.info()['name']] = harvester.extra_schema().keys()
+        fields[harvester.info()['name']] = list(harvester.extra_schema().keys())
     return fields
 
 


### PR DESCRIPTION
https://stackoverflow.com/questions/48374667/object-of-type-dict-items-is-not-json-serializable

Upstream PR: https://github.com/ckan/ckanext-harvest/pull/450